### PR TITLE
Add LandscapioAI

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -264,6 +264,11 @@
           "title": "DeepAI",
           "url": "https://deepai.org/",
           "description": "Multipurpose Chatbot with features like Video/Image/Music Generation, Image Editor, and much more."
+        },
+        {
+          "title": "LandscapioAI",
+          "url": "https://www.landscapioai.com/",
+          "description": "AI landscape design from yard photos with estimates"
         }
       ]
     },


### PR DESCRIPTION
Add LandscapioAI to the directory/list.

LandscapioAI helps homeowners upload a yard photo, generate AI landscape design ideas, and estimate outdoor project costs before hiring or DIY planning.

- Website: https://www.landscapioai.com/
- Fit: AI Design & Images category accepts image/design tools; LandscapioAI is a free/freemium AI landscape design image-planning tool.
- Contribution route checked: README.md explicitly says to add new AI tools to data/links.json and submit a Pull Request.
- Duplicate check before PR: no LandscapioAI/landscapioai.com hit in the target file; GitHub issue/PR search hits: 0.
