### PR TITLE
Add ArtImageHub to AI Design & Images

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -536,6 +536,15 @@
       "website": "https://www.aurcue.com",
       "role": "Contributor",
       "featured": false
+    },
+    {
+      "name": "ArtImageHub Team",
+      "github": "linxuaning",
+      "avatar": "https://github.com/linxuaning.png",
+      "contributions": [
+        "Added ArtImageHub to AI Design & Images"
+      ],
+      "website": "https://artimagehub.com"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -269,6 +269,11 @@
           "title": "Aurcue",
           "url": "https://www.aurcue.com",
           "description": "AI personal aesthetic assistant for color analysis, outfit upgrades, hairstyles, glasses, and daily style decisions from a photo."
+        },
+        {
+          "title": "ArtImageHub",
+          "url": "https://artimagehub.com/old-photo-restoration",
+          "description": "AI old photo restoration that repairs scratches, fading, and blur and colorizes black-and-white family photos."
         }
       ]
     },


### PR DESCRIPTION
Adds one new AI tool, **ArtImageHub**, to the *AI Design & Images* category in `data/links.json`, and adds the contributor entry per the contribution guide.

- **Title:** ArtImageHub
- **URL:** https://artimagehub.com/old-photo-restoration
- **Description:** AI old photo restoration that repairs scratches, fading, and blur and colorizes black-and-white family photos.

Both JSON files validated. Single tool added in the correct category.