### PR TITLE
Add FPVTune to AI productivity tools

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -536,6 +536,17 @@
       "website": "https://www.aurcue.com",
       "role": "Contributor",
       "featured": false
+    },
+    {
+      "name": "FPVTune Team",
+      "github": "chugzb",
+      "avatar": "https://github.com/chugzb.png",
+      "tagline": "Open-source FPV tuning tools",
+      "contributions": [
+        "Added FPVTune to AI Productivity category"
+      ],
+      "website": "https://fpvtune.com/",
+      "role": "Contributor"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -610,6 +610,11 @@
           "description": "AI data analysis and visualization tool"
         },
         {
+          "title": "FPVTune",
+          "url": "https://fpvtune.com/",
+          "description": "Betaflight log analysis and PID/filter tuning suggestions"
+        },
+        {
           "title": "Genspark AI",
           "url": "https://genspark.ai",
           "description": "AI-powered search and research assistant"


### PR DESCRIPTION
Adds FPVTune to the AI Productivity category and adds the contributor entry as requested in the project README.\n\nWhy it fits:\n- FPVTune is an open-source AI assistant for FPV drone pilots.\n- It analyzes Betaflight blackbox logs and suggests PID/filter tuning changes.\n- The tool has a working website and public GitHub repository.\n\nLocal checks:\n- npm run check-duplicates: passed, no duplicates found.\n- JSON parsing for data/links.json and data/contributors.json: passed.\n- npm run validate-contributors: currently fails because of pre-existing contributor data issues unrelated to this change, while the new FPVTune Team entry passes basic validation.