### PR TITLE
Add CallURL to AI Productivity

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -536,6 +536,16 @@
       "website": "https://www.aurcue.com",
       "role": "Contributor",
       "featured": false
+    },
+    {
+      "name": "outwrit",
+      "github": "outwrit",
+      "avatar": "https://github.com/outwrit.png",
+      "contributions": [
+        "Added CallURL to AI Productivity category"
+      ],
+      "website": "https://callurl.com",
+      "role": "Contributor"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -718,6 +718,11 @@
           "title": "IdeaTwister",
           "url": "https://ideatwister.com",
           "description": "Locally-run AI engine that turns one rough business idea into 50+ scored variations across 15 strategic angles. Built for solo founders."
+        },
+        {
+          "title": "CallURL",
+          "url": "https://callurl.com",
+          "description": "Build a free Call App in 60 seconds, then share it by link or QR to handle calls."
         }
       ]
     },


### PR DESCRIPTION
Adds CallURL to the AI Productivity category.\n\nCallURL lets users build a free Call App in 60 seconds, share it by link or QR, and handle calls for workflows like lead qualification, support, screening, surveys, and booking.\n\nChecks run:\n- npm run check-duplicates\n- npm run validate-contributors (fails on pre-existing contributor data: existing LinkedIn format/unknown fields; CallURL contributor entry passes)\n- git diff --check