### PR TITLE
feat(tools): add Catoon to AI Design & Images

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -536,6 +536,17 @@
       "website": "https://www.aurcue.com",
       "role": "Contributor",
       "featured": false
+    },
+    {
+      "name": "Justin",
+      "github": "zuoyouxuan",
+      "avatar": "https://github.com/zuoyouxuan.png",
+      "tagline": "AI product builder",
+      "contributions": [
+        "Added Catoon to AI Design & Images"
+      ],
+      "website": "https://catoon.xyz",
+      "role": "Contributor"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -269,6 +269,11 @@
           "title": "Aurcue",
           "url": "https://www.aurcue.com",
           "description": "AI personal aesthetic assistant for color analysis, outfit upgrades, hairstyles, glasses, and daily style decisions from a photo."
+        },
+        {
+          "title": "Catoon",
+          "url": "https://catoon.xyz",
+          "description": "Turn long stories into editable AI comic chapters."
         }
       ]
     },


### PR DESCRIPTION
Adds Catoon to the AI Design & Images category and adds the contributor record requested by the contribution guide.\n\nCatoon helps creators turn long stories into editable AI comic chapters with reusable characters, storyboards, speech bubbles, rendered panels, and exports.\n\nValidation run:\n- npm run check-duplicates\n- JSON parse check for data/links.json and data/contributors.json\n- git diff --check\n\nNote: npm run validate passed with warnings from existing unreachable third-party links. npm run validate-contributors currently fails on an existing contributor LinkedIn formatting issue unrelated to this change.\n\nI am associated with Catoon and submitting this transparently.