### PR TITLE
feat(tools): add Auferet to AI Entertainment

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -744,6 +744,11 @@
           "title": "Infinite Craft",
           "url": "https://neal.fun/infinite-craft/",
           "description": "Infinite Craft is an AI-powered game where you start with four basic elements and combine them to discover a virtually endless universe of creations."
+        },
+        {
+          "title": "Auferet",
+          "url": "https://auferet.com",
+          "description": "AI game master for solo text adventures and tabletop RPGs, with long-term story memory and uploadable lore"
         }
       ]
     },


### PR DESCRIPTION
Adds **Auferet** to the **AI Entertainment** category in `data/links.json`.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs, with long-term story memory and uploadable lore for consistent worlds. Free tier plus paid plans; runs in the browser and on Android. Entry follows the existing `title`/`url`/`description` schema.