### PR TITLE
feat(tools): add Memex to AI Productivity category

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -743,6 +743,11 @@
           "title": "CallURL",
           "url": "https://callurl.com",
           "description": "Build a free Call App in 60 seconds, then share it by link or QR to handle calls."
+        },
+        {
+          "title": "Memex",
+          "url": "https://www.memexlab.ai/",
+          "description": "Private AI journal for searchable life memories"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Added Memex to the AI Productivity category
- Uses the official website URL: https://www.memexlab.ai/

## Validation
- node scripts/validate-links.js --duplicates-only
- node scripts/validate-links.js (passes with existing warnings)