### PR TITLE
Add igly.ai to AI design tools

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -281,6 +281,11 @@
           "description": "AI personal aesthetic assistant for color analysis, outfit upgrades, hairstyles, glasses, and daily style decisions from a photo."
         },
         {
+          "title": "igly.ai",
+          "url": "https://igly.ai",
+          "description": "Free AI image editor for background removal, inpainting, upscaling, generative fill, and product photo workflows."
+        },
+        {
           "title": "Catoon",
           "url": "https://catoon.xyz",
           "description": "Turn long stories into editable AI comic chapters."


### PR DESCRIPTION
## Summary

- Add igly.ai to the AI Design & Images category
- Keep the entry concise and aligned with the existing tool list format

## Why it fits

igly.ai is a free AI image editor for background removal, inpainting, upscaling, generative fill, and product photo workflows. It complements the existing AI image/design tools such as Remove.bg, Pixlr, PhotoCut, and Let’s Enhance.

Demo: https://www.youtube.com/watch?v=HB2E1WZ12is

## Checks

- `jq empty data/links.json`
- `npm run check-duplicates`
- `npm run validate` (passes with existing external URL warnings)