### PR TITLE
PinZheng(tools): add codex-profiles to AI coding

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -604,6 +604,16 @@
         "Added AI Badger to AI Coding & Development"
       ],
       "role": "Contributor"
+    },
+    {
+      "name": "Chai Pin Zheng",
+      "github": "Ducksss",
+      "avatar": "https://github.com/Ducksss.png",
+      "tagline": "Open-source developer tools builder",
+      "contributions": [
+        "Added codex-profiles to AI Coding & Development"
+      ],
+      "role": "Contributor"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -448,6 +448,11 @@
           "description": "AI-first code editor with free features for real-time coding assistance"
         },
         {
+          "title": "codex-profiles",
+          "url": "https://github.com/Ducksss/codex-profiles",
+          "description": "Manage named Codex and ChatGPT profiles"
+        },
+        {
           "title": "AI Badger",
           "url": "https://github.com/PVRLabs/aibadger",
           "description": "Extract focused repo context locally for any AI chat"


### PR DESCRIPTION
## Description

Adds [codex-profiles](https://github.com/Ducksss/codex-profiles) to **AI Coding & Development**. The MIT-licensed Bash wrapper gives each named workflow its own `CODEX_HOME`; on macOS it can also launch separate ChatGPT Desktop windows without copying tokens.

## Type of Change

- [x] New AI tool addition
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Code refactoring

## Tool Details

- **Tool Name:** codex-profiles
- **Category:** AI Coding & Development
- **Why it is valuable:** It helps developers keep personal, work, school, client, or test Codex contexts separate.
- **Free tier confirmed:** Yes — the project is completely free and MIT licensed.

## Changes Made

- [x] Added the tool to `data/links.json`
- [x] Added the contributor to `data/contributors.json`
- [x] Verified the tool is not a duplicate
- [x] Verified the source URL is reachable

## Testing

- `npm run validate-json` — passed
- Entry-specific URL, uniqueness, category, and 60-character description checks — passed
- The existing repo-wide duplicate check still reports the pre-existing `ImagineClip` duplicates.
- The existing contributor validator still reports malformed older contributor records; the new `Ducksss` record passes its required-field and uniqueness checks.
