### PR TITLE
Add DaoXE (OpenAI-compatible LLM gateway)

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -536,6 +536,11 @@
           "title": "tokencost",
           "url": "https://github.com/alvabillwu/tokencost",
           "description": "LLM token usage and cost calculator for OpenAI and Anthropic models"
+        },
+        {
+          "title": "DaoXE",
+          "url": "https://daoxe.com",
+          "description": "OpenAI-compatible multi-model LLM API gateway (Claude/GPT/Gemini/DeepSeek) with one API key."
         }
       ]
     },


### PR DESCRIPTION
Adds **DaoXE** to the **AI Coding & Development** category in data/links.json.

DaoXE is an OpenAI-compatible, multi-model API gateway — one base URL (https://daoxe.com/v1) and key for Claude, GPT, Gemini, DeepSeek and more. Useful for developers wiring tools (Cursor, Cline, Continue) to a single endpoint.

Disclosure: DaoXE is a service we operate.

Made with [Cursor](https://cursor.com)