### PR TITLE
feat(tools): add Echo99 to AI Productivity

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -614,6 +614,7 @@
         "Added Markstream to AI Coding & Development"
       ],
       "website": "https://markstream.simonhe.me/",
+      "role": "Contributor"
     },
     {
       "name": "Chai Pin Zheng",
@@ -623,6 +624,17 @@
       "contributions": [
         "Added codex-profiles to AI Coding & Development"
       ],
+      "role": "Contributor"
+    },
+    {
+      "name": "Tomas Zeman",
+      "github": "ertra",
+      "avatar": "https://github.com/ertra.png",
+      "tagline": "Developer of Echo99",
+      "contributions": [
+        "Added Echo99 to AI Productivity"
+      ],
+      "website": "https://www.echo99.app/",
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -675,6 +675,11 @@
           "description": "Free AI meeting transcription"
         },
         {
+          "title": "Echo99",
+          "url": "https://www.echo99.app/",
+          "description": "Local Mac call recording and speaker-labeled transcripts"
+        },
+        {
           "title": "Calendly AI",
           "url": "https://calendly.com",
           "description": "Smart scheduling with free plan"


### PR DESCRIPTION
# Pull Request

## Description

Adds Echo99 to the **AI Productivity** category and adds the developer to the contributors list.

Echo99 is a free native macOS call recorder that captures microphone and system audio separately, then transcribes and labels speakers on-device. Recordings and transcripts remain local.

Disclosure: I am the developer of Echo99.

## Type of Change

- [x] New AI tool addition
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Code refactoring

## Tool Details

**Tool Name:** Echo99  
**Category:** AI Productivity  
**Why it's valuable:** It provides bot-free call recording and speaker-labeled transcription without uploading meeting content.  
**Free tier confirmed:** Yes — Echo99 is completely free.

## Changes Made

- [x] Added new tool to `data/links.json`
- [x] Updated `data/contributors.json` with my information
- [x] Tested changes locally
- [x] Verified tool is not a duplicate
- [x] Ensured tool is free

The contributor addition also restores the missing required `role` field on the preceding Simon He record. That field was lost during an upstream merge conflict and left `contributors.json` as invalid JSON.

## Testing

- [x] Both data files parse as valid JSON
- [x] Echo99's title and URL occur exactly once
- [x] The description is within the documented 60-character limit
- [x] The public page and download endpoint are reachable
- [x] `git diff --cached --check` passes

Repository-wide validation notes:

- `npm run check-duplicates` still reports the pre-existing `ImagineClip` duplicates.
- `npm run validate-contributors -- --quick` now parses the file, then reports older contributor records with missing roles, a duplicate GitHub user, and one malformed LinkedIn value. The new `ertra` record passes its required-field and uniqueness checks.

## Checklist

- [x] My changes follow the project's data format
- [x] I have performed a self-review
- [x] I have added myself to the contributors list
- [x] I have read and followed the contribution guidelines
