### PR TITLE
Add ImageChanger to AI Design & Images

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -614,6 +614,7 @@
         "Added Markstream to AI Coding & Development"
       ],
       "website": "https://markstream.simonhe.me/",
+      "role": "Contributor"
     },
     {
       "name": "Chai Pin Zheng",
@@ -623,6 +624,17 @@
       "contributions": [
         "Added codex-profiles to AI Coding & Development"
       ],
+      "role": "Contributor"
+    },
+    {
+      "name": "Zenin",
+      "github": "zenanythin",
+      "avatar": "https://github.com/zenanythin.png",
+      "tagline": "Indie developer",
+      "contributions": [
+        "Added ImageChanger to AI Design & Images"
+      ],
+      "website": "https://aiimagechanger.app/",
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -206,6 +206,11 @@
           "description": "Transform any image with simple text prompts"
         },
         {
+          "title": "ImageChanger",
+          "url": "https://aiimagechanger.app/",
+          "description": "AI photo editor with 38 focused transformation workflows"
+        },
+        {
           "title": "Pixlr",
           "url": "https://pixlr.com/",
           "description": "Edit photos, generate images, and design freely with Pixlr's powerful AI tools."


### PR DESCRIPTION
# Pull Request

## Description

Adds ImageChanger to the **AI Design & Images** category and adds the submitter to the contributors list. ImageChanger is a freemium browser-based AI photo editor with 38 focused transformation workflows.

Disclosure: I am the developer of ImageChanger.

## Changes

- Added ImageChanger to `data/links.json`
- Added the contributor entry to `data/contributors.json`
- Restored the missing required `role` on the preceding Simon He record so the JSON parses

## Validation

- Both JSON files parse successfully
- ImageChanger title and URL occur once in the tools database
- Description is 56 characters, within the documented 60-character limit
- `git diff --check` passes
- Repository-wide scripts still report pre-existing ImagineClip duplicates and older contributor validation issues unrelated to this change