### PR TITLE
feat(tools): add WizGenerator Story Generator

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -613,7 +613,7 @@
       "contributions": [
         "Added Markstream to AI Coding & Development"
       ],
-      "website": "https://markstream.simonhe.me/",
+      "website": "https://markstream.simonhe.me/"
     },
     {
       "name": "Chai Pin Zheng",
@@ -623,6 +623,17 @@
       "contributions": [
         "Added codex-profiles to AI Coding & Development"
       ],
+      "role": "Contributor"
+    },
+    {
+      "name": "WizGenerator",
+      "github": "wizgenerator",
+      "avatar": "https://github.com/wizgenerator.png",
+      "tagline": "Browser-based generator tools",
+      "contributions": [
+        "Added WizGenerator Story Generator to AI Writing & Content"
+      ],
+      "website": "https://wizgenerator.com",
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -143,6 +143,11 @@
           "title": "Junia AI",
           "url": "https://junia.ai",
           "description": "Writing assistant that helps with rephrasing, summarization, SEO adjustments, and content planning."
+        },
+        {
+          "title": "WizGenerator Story Generator",
+          "url": "https://wizgenerator.com/tools/story-generator/",
+          "description": "Free AI story drafts with genre, tone and POV controls"
         }
       ]
     },


### PR DESCRIPTION
# Pull Request

## Description

Adds WizGenerator Story Generator to the AI Writing & Content category and adds the required brand contributor entry. It also removes one pre-existing trailing comma from the prior contributor record so contributors.json remains valid JSON.

## Type of Change

- [x] New AI tool addition
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Code refactoring

## Tool Details

- **Tool Name:** WizGenerator Story Generator
- **Category:** AI Writing & Content
- **Why it's valuable:** Generates a complete fiction draft from a premise with genre, tone, length, and POV controls.
- **Free tier confirmed:** Yes — browser-tested without an account.

## Changes Made

- [x] Added new tool to `data/links.json`
- [x] Updated `data/contributors.json` with the WizGenerator brand profile
- [x] Verified the direct tool page and generation flow in a browser
- [x] Verified the tool title and URL occur exactly once
- [x] Kept the description under 60 characters

## Testing

- [x] Both edited JSON files parse successfully
- [x] Targeted duplicate check confirms one WizGenerator title/URL
- [x] `git diff --check` passes
- [ ] Full repository validation passes

The full validator still reports a pre-existing duplicate for ImagineClip across AI Design & Images and AI Video & Audio, plus existing unreachable-link warnings. This PR does not add those failures.

## Checklist

- [x] Followed the existing data structure and project guidelines
- [x] Performed a self-review
- [x] Added the brand contributor record
- [x] Read and followed the [Contributing Guidelines](docs/CONTRIBUTING.md)

## Additional Notes

Disclosure: submitted on behalf of WizGenerator. No personal name or private email is included.