### PR TITLE
Add SaaSCity

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -828,6 +828,11 @@
           "title": "Memex",
           "url": "https://www.memexlab.ai/",
           "description": "Private AI journal for searchable life memories"
+        },
+        {
+          "title": "SaaSCity",
+          "url": "https://saascity.io",
+          "description": "Free gamified SaaS & AI directory — launch on a live city map"
         }
       ]
     },


### PR DESCRIPTION
Adds **SaaSCity** to the AI Productivity category in `data/links.json`.

- Site: https://saascity.io
- Submit: https://saascity.io/submit
- Gamified SaaS directory where every listing becomes a building on a live isometric city map.
- Domain Rating 46 (Ahrefs), free listing, dofollow, every submission manually reviewed inside 24h.

Happy to adjust the wording or move it if it belongs somewhere else.
