### PR TITLE
Add ImageChanger to AI Design & Images

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -614,6 +614,7 @@
         "Added Markstream to AI Coding & Development"
       ],
       "website": "https://markstream.simonhe.me/",
+      "role": "Contributor"
     },
     {
       "name": "Chai Pin Zheng",
@@ -623,6 +624,17 @@
       "contributions": [
         "Added codex-profiles to AI Coding & Development"
       ],
+      "role": "Contributor"
+    },
+    {
+      "name": "Zenin",
+      "github": "zenanythin",
+      "avatar": "https://github.com/zenanythin.png",
+      "tagline": "Indie developer",
+      "contributions": [
+        "Added ImageChanger to AI Design & Images"
+      ],
+      "website": "https://aiimagechanger.app/",
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -206,6 +206,11 @@
           "description": "Transform any image with simple text prompts"
         },
         {
+          "title": "ImageChanger",
+          "url": "https://aiimagechanger.app/",
+          "description": "AI photo editor with 38 focused transformation workflows"
+        },
+        {
           "title": "Pixlr",
           "url": "https://pixlr.com/",
           "description": "Edit photos, generate images, and design freely with Pixlr's powerful AI tools."


### PR DESCRIPTION
Adds [ImageChanger](https://aiimagechanger.app/) to the AI Design & Images category.

ImageChanger is a browser-based AI photo editor with 38 focused transformation workflows (backgrounds, objects, clothing, colors, styles) driven by plain-language prompts. Freemium: new users get 10 credits valid for 30 days, no credit card required.

This re-submits the change from #209, which was closed when its fork was deleted. It also fixes a pre-existing JSON syntax error in `data/contributors.json` (trailing comma + missing `role` in the Markstream entry) that left the file invalid.