### PR TITLE
feat(tools): add Rao Edits to AI Design & Images

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -613,7 +613,7 @@
       "contributions": [
         "Added Markstream to AI Coding & Development"
       ],
-      "website": "https://markstream.simonhe.me/",
+      "website": "https://markstream.simonhe.me/"
     },
     {
       "name": "Chai Pin Zheng",
@@ -623,6 +623,17 @@
       "contributions": [
         "Added codex-profiles to AI Coding & Development"
       ],
+      "role": "Contributor"
+    },
+    {
+      "name": "Rao Edits",
+      "github": "coolcbq",
+      "avatar": "https://github.com/coolcbq.png",
+      "tagline": "AI image generation and editing platform",
+      "contributions": [
+        "Added Rao Edits to AI Design & Images"
+      ],
+      "website": "https://raoedits.top/",
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -299,6 +299,11 @@
           "title": "Catoon",
           "url": "https://catoon.xyz",
           "description": "Turn long stories into editable AI comic chapters."
+        },
+        {
+          "title": "Rao Edits",
+          "url": "https://raoedits.top/",
+          "description": "Free AI image generation and reference-image editing"
         }
       ]
     },


### PR DESCRIPTION
## Description

Adds Rao Edits to **AI Design & Images** and adds the submitting account to the contributors data. Rao Edits provides browser-based AI image generation and reference-image editing for product, social, and creative visuals.

This also removes an existing trailing comma from `data/contributors.json` so the file is valid JSON and the required contributor entry can be added safely.

## Type of Change

- [x] New AI tool addition
- [x] Data validation fix

## Tool Details

- **Tool Name**: Rao Edits
- **Category**: AI Design & Images
- **Why it is valuable**: Combines text-to-image generation with reference-image editing in one browser workflow.
- **Free tier confirmed**: Yes — the public FAQ states that free users receive a limited number of generations per day.

## Verification

- [x] `https://raoedits.top/` returns HTTP 200
- [x] Free-tier disclosure was checked on the public site
- [x] Tool title and URL are not already present in the catalog
- [x] Description is 52 characters, below the documented 60-character limit
- [x] `npm run validate-json` passes for both data files
- [x] `npm run validate-contributors` recognizes the Rao Edits entry without entry-specific errors
- [x] Target-specific data contract check passes
- [x] `git diff --check` passes

The repository-wide duplicate and contributor validators still report unrelated pre-existing catalog/contributor issues (for example, the existing duplicate ImagineClip entry and older contributor metadata). This PR does not add any new duplicate or contributor validation error.

## Disclosure

This submission is made on behalf of Rao Edits. The description and PR text were drafted with AI assistance and reviewed before submission.