### PR TITLE
Add Fortuneteller.Today

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -859,6 +859,11 @@
           "title": "Auferet",
           "url": "https://auferet.com",
           "description": "AI game master for solo text adventures and tabletop RPGs, with long-term story memory and uploadable lore"
+        },
+        {
+          "title": "Fortuneteller.Today",
+          "url": "https://www.fortuneteller.today",
+          "description": "AI tarot, astrology, BaZi, numerology, and rune readings."
         }
       ]
     },


### PR DESCRIPTION
Adds Fortuneteller.Today to the AI Entertainment category.

Details:
- Name: Fortuneteller.Today
- URL: https://www.fortuneteller.today
- Category: AI Entertainment
- Description: AI tarot, astrology, BaZi, numerology, and rune readings.

Validation:
- Confirmed data/links.json parses successfully and contains the new Fortuneteller.Today entry.
- npm run check-duplicates currently fails because of a pre-existing duplicate ImagineClip entry in AI Design and Images / AI Video and Audio, unrelated to this change. The new Fortuneteller.Today entry is unique.