### PR TITLE
feat(tools): add IdeaHunter to AI Productivity

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -828,6 +828,11 @@
           "title": "Memex",
           "url": "https://www.memexlab.ai/",
           "description": "Private AI journal for searchable life memories"
+        },
+        {
+          "title": "IdeaHunter",
+          "url": "https://ideahunter.today",
+          "description": "AI startup idea research for solo founders"
         }
       ]
     },


### PR DESCRIPTION
Adds IdeaHunter to the AI Productivity category.

IdeaHunter helps solo founders research demand-backed app and micro-SaaS ideas before building, using public pain signals, market evidence, MVP scope, and monetization paths. It has a freemium/subscription model.

Validation notes:
- Verified https://ideahunter.today returns HTTP 200 before submission.
- `npm run validate-json` currently fails because existing `data/contributors.json` is invalid JSON before this change.
- `npm run check-duplicates` currently fails on an existing ImagineClip duplicate before this change.

Disclosure: submitted by an authorized agent for IdeaHunter. No payment, CAPTCHA, email verification, phone, address, or reciprocal backlink required.