### PR TITLE
feat(tools): add Agent Coordinator to AI Coding & Development

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -646,6 +646,17 @@
       ],
       "website": "https://wavect.io/",
       "role": "Contributor"
+    },
+    {
+      "name": "Alan Hoffmeister",
+      "github": "alanhoff",
+      "avatar": "https://github.com/alanhoff.png",
+      "tagline": "Open-source developer",
+      "contributions": [
+        "Added Agent Coordinator to AI Coding & Development"
+      ],
+      "website": "https://github.com/alanhoff/agent-coordinator",
+      "role": "Contributor"
     }
   ]
 }

--- a/data/links.json
+++ b/data/links.json
@@ -551,6 +551,11 @@
           "title": "SEMAPRAX",
           "url": "https://wavect.io/semaprax/",
           "description": "Pre-alpha language and compiler for semantic agent edits"
+        },
+        {
+          "title": "Agent Coordinator",
+          "url": "https://github.com/alanhoff/agent-coordinator",
+          "description": "Bounded Codex work graphs with resumable local state"
         }
       ]
     },


### PR DESCRIPTION
## Description

Adds [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) to **AI Coding & Development**. It is a per-user Codex skill that represents complex tasks as bounded work graphs and records revisioned workflow state locally. Specialist agents are optional; the same node lifecycle runs inline when delegation is unavailable.

I maintain the project. On 2026-09-01, I tested commit [`fb3d646`](https://github.com/alanhoff/agent-coordinator/commit/fb3d64688a9e1b7c02a114a14faac1219ec10f51) by using it inline to track the venue gate, preparation, validation, and submission workflow for this contribution.

## Type of Change

- [x] New AI tool addition
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Code refactoring

## Tool Details

- **Tool Name:** Agent Coordinator
- **Category:** AI Coding & Development
- **Why it is valuable:** It gives longer Codex tasks explicit dependencies, acceptance checks, and local state, and requires uncertain work to be reconciled before retry.
- **Free tier confirmed:** Yes. The project itself is completely free and MIT licensed.

## Changes Made

- [x] Added the tool to `data/links.json`
- [x] Added the contributor to `data/contributors.json`
- [x] Tested the change locally
- [x] Verified the tool is not a duplicate
- [x] Confirmed the tool is completely free and open source

## Testing

- [x] Focused JSON, schema, uniqueness, URL, and description-length checks pass for the new records
- [x] `git diff --check` passes
- [x] The local site renders the Agent Coordinator card and source link in the intended category

## Validation note

The repository-wide duplicate check already fails on `master` because `ImagineClip` appears more than once. `data/contributors.json` also has a trailing comma in the unchanged Simon He record, so the repository-wide JSON and contributor validators cannot parse that file. Focused before/after checks confirm this PR adds no duplicate, schema error, or malformed field.

## Checklist

- [x] My change follows the project's existing data style
- [x] I performed a self-review
- [x] I added myself to the contributors list
- [x] My change introduces no new warning or error
- [x] I read and followed the [Contributing Guidelines](https://github.com/ArshdeepGrover/ai-tools-manager/blob/master/docs/CONTRIBUTING.md)

## Additional Notes

The listing description is 52 characters, within the 60-character limit. The source URL is public and returned HTTP 200 during validation.
