### PR TITLE
feat(tools): add Agent QA and repair catalog data

### DIFF
--- a/data/contributors.json
+++ b/data/contributors.json
@@ -397,7 +397,7 @@
       "name": "Prachi Sharma",
       "github": "dev-prachi",
       "avatar": "https://github.com/dev-prachi.png",
-      "linkedin": "www.linkedin.com/in/prachi-sharma123",
+      "linkedin": "prachi-sharma123",
       "tagline": "Aspiring Software Developer",
       "contributions": [
         "Added hover effect in the links of navbar"
@@ -554,7 +554,8 @@
       "contributions": [
         "Added ArtImageHub to AI Design & Images"
       ],
-      "website": "https://artimagehub.com"
+      "website": "https://artimagehub.com",
+      "role": "Contributor"
     },
     {
       "name": "FPVTune Team",
@@ -562,18 +563,11 @@
       "avatar": "https://github.com/chugzb.png",
       "tagline": "Open-source FPV tuning tools",
       "contributions": [
-        "Added FPVTune to AI Productivity category"
-      ]
-    },
-    {
-      "website": "https://fpvtune.com/",
-      "name": "chugzb",
-      "github": "chugzb",
-      "avatar": "https://github.com/chugzb.png",
-      "tagline": "AI tools contributor",
-      "contributions": [
+        "Added FPVTune to AI Productivity category",
         "Added Roblox GUI Maker to AI Game & Strategy"
-      ]
+      ],
+      "website": "https://fpvtune.com/",
+      "role": "Contributor"
     },
     {
       "name": "outwrit",
@@ -582,7 +576,8 @@
       "contributions": [
         "Added CallURL to AI Productivity category"
       ],
-      "website": "https://callurl.com"
+      "website": "https://callurl.com",
+      "role": "Contributor"
     },
     {
       "name": "Justin",
@@ -614,6 +609,7 @@
         "Added Markstream to AI Coding & Development"
       ],
       "website": "https://markstream.simonhe.me/",
+      "role": "Contributor"
     },
     {
       "name": "Ofek Ron",
@@ -645,6 +641,16 @@
         "Added SEMAPRAX to AI Coding & Development"
       ],
       "website": "https://wavect.io/",
+      "role": "Contributor"
+    },
+    {
+      "name": "Pranshu Chittora",
+      "github": "pranshuchittora",
+      "avatar": "https://avatars.githubusercontent.com/u/32242596?v=4",
+      "contributions": [
+        "Added Agent QA to AI Coding & Development",
+        "Repaired catalog duplicates and contributor data validation"
+      ],
       "role": "Contributor"
     }
   ]

--- a/data/links.json
+++ b/data/links.json
@@ -281,11 +281,6 @@
           "description": "Multipurpose Chatbot with features like Video/Image/Music Generation, Image Editor, and much more."
         },
         {
-          "title": "ImagineClip",
-          "url": "https://imagineclip.com",
-          "description": "AI video generator for avatar clips, stylized scenes, and social-ready content."
-        },
-        {
           "title": "Aurcue",
           "url": "https://www.aurcue.com",
           "description": "AI personal aesthetic assistant for color analysis, outfit upgrades, hairstyles, glasses, and daily style decisions from a photo."
@@ -362,6 +357,11 @@
       "name": "AI Coding & Development",
       "icon": "💻",
       "links": [
+        {
+          "title": "Agent QA",
+          "url": "https://vostride.com/docs/agent-qa",
+          "description": "AI web/mobile QA; FSL-1.1-ALv2; model costs separate"
+        },
         {
           "title": "GitHub Copilot",
           "url": "https://github.com/features/copilot",
@@ -602,11 +602,6 @@
           "title": "Vmaker AI",
           "url": "https://www.vmaker.com/",
           "description": "Generate videos from text, voice, or docs and edit with AI"
-        },
-        {
-          "title": "ImagineClip",
-          "url": "https://imagineclip.com?ref=ai-tools-manager",
-          "description": "AI video generator for social clips and avatars"
         },
         {
           "title": "Flow",


### PR DESCRIPTION
## Description

Add Agent QA to **AI Coding & Development** and repair existing data errors that prevent the required validators and contributor display from working. The new tool description is 52 characters and names FSL-1.1-ALv2 and separate model costs.

I maintain Agent QA. This contribution was prepared with AI assistance.

## Type of Change

- [x] New AI tool addition
- [x] Bug fix

## Tool Details

**Tool Name:** Agent QA
**Category:** AI Coding & Development
**Why it is useful:** Natural-language end-to-end testing of web, Android, and iOS apps, with execution memory and CLI, dashboard, and MCP interfaces.
**Free use confirmed:** The software has no charge for uses permitted by [FSL-1.1-ALv2](https://github.com/vostride/agent-qa/blob/main/LICENSE.md). Models, hosting, and device providers are supplied separately and may charge. This is source-available software; it does not include a free hosted inference allowance. The [quickstart](https://vostride.com/docs/agent-qa/quickstart) documents local and hosted model options.

## Changes Made

- [x] Add the tool to `data/links.json` and my required profile to `data/contributors.json`.
- [x] Verify no existing Agent QA title, URL, issue, or PR duplicate.
- [x] Consolidate three ImagineClip records into the existing clean-URL entry in AI Video & Audio. The [vendor page](https://imagineclip.com/) confirms the video focus; one entry remains discoverable.
- [x] Add the documented default Contributor role where required. Adding the missing role to the Markstream contributor also resolves the existing invalid trailing comma.
- [x] Consolidate the duplicate chugzb profiles, retaining both contribution records and the website.
- [x] Normalize the existing LinkedIn field to the username expected by the validator and renderer, preserving the profile target.

There are 184 tool records after removing two duplicates and adding Agent QA. There are 54 contributor records after merging one duplicate and adding my profile.

## Testing

- [x] `npm run check-duplicates` passes: 184 unique links across 10 categories.
- [x] `npm run validate-json` passes for both files.
- [x] `node scripts/validate-contributors.js --quick` passes for 54 contributors.
- [x] `npm run validate` passes with 44 existing-link warnings: 42 URLs did not answer the script's HEAD check and two domains are marked experimental. Agent QA's new URL is reachable.
- [x] Isolated Chrome 152: Agent QA search finds one card; its category retains it and an unrelated category excludes it; no-results handling works; Coding expands from six to 39 cards and collapses again; contributor search finds the new profile without fallback data; the card fits at 390 px with license and cost text visible.
- [x] `git diff --check` passes.
- [ ] Every existing external link responds successfully. The 42 HEAD-check warnings above remain; three existing favicon services also returned 404 in the browser. There were no uncaught page errors.

Tool functionality check: earlier today, I launched published `agent-qa@0.1.21 mcp` through the official MCP SDK, discovered 33 tools, and exercised discovery, schemas, ID validation, and invalid-definition rejection. That smoke check did not call an LLM provider or run a browser/device test through Agent QA.

## Checklist

- [x] Followed the contribution and commit-message guides.
- [x] Reviewed the exact changes and added the required contributor record.
- [x] Tested the new listing locally and preserved unrelated tool records.
